### PR TITLE
#18 심박수 모니터링 워크매니저 구현

### DIFF
--- a/WearOS/app/src/main/AndroidManifest.xml
+++ b/WearOS/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.BODY_SENSORS" />
@@ -7,6 +8,8 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <uses-feature android:name="android.hardware.type.watch" />
 
@@ -60,6 +63,19 @@
                     android:scheme="wear" />
             </intent-filter>
         </service>
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+
+        </provider>
+
     </application>
 
 </manifest>

--- a/WearOS/app/src/main/java/com/sandy/logisync/MyApplication.kt
+++ b/WearOS/app/src/main/java/com/sandy/logisync/MyApplication.kt
@@ -1,7 +1,19 @@
 package com.sandy.logisync
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
-class MyApplication:Application()
+class MyApplication : Application(), Configuration.Provider {
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+}

--- a/WearOS/app/src/main/java/com/sandy/logisync/data/health/HealthMeasureServiceManager.kt
+++ b/WearOS/app/src/main/java/com/sandy/logisync/data/health/HealthMeasureServiceManager.kt
@@ -1,5 +1,6 @@
 package com.sandy.logisync.data.health
 
+import android.util.Log
 import androidx.health.services.client.MeasureCallback
 import androidx.health.services.client.MeasureClient
 import androidx.health.services.client.awaitWithException
@@ -10,9 +11,11 @@ import androidx.health.services.client.data.DataTypeAvailability
 import androidx.health.services.client.data.DeltaDataType
 import com.sandy.logisync.wearable.health.HeartRateDTO
 import com.sandy.logisync.wearable.health.MeasureMessage
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flowOn
 import java.time.LocalDateTime
 import javax.inject.Inject
 
@@ -31,6 +34,7 @@ class HeartRateServiceManager @Inject constructor(
                 dataType: DeltaDataType<*, *>,
                 availability: Availability
             ) {
+                Log.e("확인", "onAvailabilityChanged: $availability")
                 val measureAvailability =
                     if (availability == DataTypeAvailability.UNAVAILABLE_DEVICE_OFF_BODY) availability
                     else DataTypeAvailability.ACQUIRING
@@ -39,6 +43,7 @@ class HeartRateServiceManager @Inject constructor(
 
             override fun onDataReceived(data: DataPointContainer) {
                 val heartRateBpm = data.getData(DataType.HEART_RATE_BPM)[0].value
+                Log.e("확인", "onDataReceived: $heartRateBpm")
                 if (heartRateBpm > 0) {
                     val heartRateDTO = HeartRateDTO(
                         date = LocalDateTime.now(),
@@ -61,5 +66,5 @@ class HeartRateServiceManager @Inject constructor(
         awaitClose {
             measureClient.unregisterMeasureCallbackAsync(DataType.HEART_RATE_BPM, callback)
         }
-    }
+    }.flowOn(Dispatchers.Main)
 }

--- a/WearOS/app/src/main/java/com/sandy/logisync/presentation/ui/MainActivity.kt
+++ b/WearOS/app/src/main/java/com/sandy/logisync/presentation/ui/MainActivity.kt
@@ -26,6 +26,7 @@ import com.sandy.logisync.presentation.ui.screens.NotInitialPairedScreen
 import com.sandy.logisync.presentation.ui.screens.PermissionScreen
 import com.sandy.logisync.presentation.ui.screens.WatchScreen
 import com.sandy.logisync.presentation.ui.theme.LogisyncWearTheme
+import com.sandy.logisync.wearable.health.HeartRateMonitoringWorker
 import com.sandy.logisync.wearable.service.MyWearableListenerService
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
@@ -107,7 +108,9 @@ class MainActivity : ComponentActivity() {
         mainViewModel.isGrantedPermission
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { isGranted ->
-                //if (isGranted) PassiveDataMonitoringWorker.registerWorker(this)
+                if (isGranted) {
+                    HeartRateMonitoringWorker.registerWorker(this)
+                }
             }
             .launchIn(lifecycleScope)
     }

--- a/WearOS/app/src/main/java/com/sandy/logisync/wearable/health/HeartRateMonitoringWorker.kt
+++ b/WearOS/app/src/main/java/com/sandy/logisync/wearable/health/HeartRateMonitoringWorker.kt
@@ -1,0 +1,165 @@
+package com.sandy.logisync.wearable.health
+
+import android.content.Context
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.sandy.logisync.data.health.HealthMeasureRepository
+import com.sandy.logisync.data.network.NetworkRepository
+import com.sandy.logisync.model.MeasuredAvailability
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import java.time.DayOfWeek
+import java.time.Duration
+import java.time.LocalDateTime
+
+/**
+ * HeartRateMonitoringWorker 심박수 모니터링 워커
+ * 1) 하루 근무시간에만 수집한다. 아침 8시를 첫 모니터링, 오후 7시를 마지막 모니터링으로
+ * 2) 주말에는 모니터링하지 않는다.
+ * 3) 모니터링 시간은 30분마다 한다.
+ */
+@HiltWorker
+class HeartRateMonitoringWorker @AssistedInject constructor(
+    @Assisted private val context: Context,
+    @Assisted params: WorkerParameters,
+    private val healthMeasureRepository: HealthMeasureRepository,
+    private val networkRepository: NetworkRepository,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        Log.e("확인", "doWork: 워커 실행 ${LocalDateTime.now()}")
+        monitorHeartRate()
+        //registerNextMonitoring()
+        return Result.success()
+    }
+
+    private var num = 0
+    private fun monitorHeartRate() {
+        CoroutineScope(Dispatchers.IO).launch {
+            healthMeasureRepository.getMeasuredHeartRate().onEach {
+                // num++
+                if (it.availability == MeasuredAvailability.UNAVAILABLE_DEVICE_OFF_BODY ||
+                    it.availability == MeasuredAvailability.UNAVAILABLE
+                ) cancel()
+                Log.e("확인", "monitorHeartRate: 이거1 $num, ${it.availability}")
+            }.filter {
+                it.availability == MeasuredAvailability.AVAILABLE
+            }.collect {
+                val heartRate = it.heartRate
+                heartRate?.let { heartRate ->
+                    Log.e("확인", "monitorHeartRate: 이거2 $heartRate")
+                    networkRepository.updateHeartRate(heartRate.bpm, heartRate.time)
+                        .catch { error ->
+                            Log.e("확인", "monitorHeartRate: $error")
+                        }.collect()
+                }
+            }
+        }
+    }
+
+    private fun registerNextMonitoring() {
+        registerWorker(context)
+    }
+
+    companion object {
+        private const val WORK_NAME = "heart_rate_monitoring_worker"
+        fun registerWorker(
+            context: Context,
+        ) {
+            val delay = getNextMonitoringDelay()
+            Log.e("확인", "registerWorker: $delay")
+            val workRequest = OneTimeWorkRequestBuilder<HeartRateMonitoringWorker>()
+                .setInitialDelay(delay)
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                WORK_NAME,
+                ExistingWorkPolicy.REPLACE,
+                workRequest
+            )
+        }
+
+        private fun getNextMonitoringDelay(): Duration {
+            val nextMonitoringTime = getNextMonitoringTime()
+            val currentTime = LocalDateTime.now()
+            //val nextMonitoringTime = currentTime.plusMinutes(1)
+            val delay = Duration.between(currentTime, nextMonitoringTime)
+            Log.e("확인", "getNextMonitoringDelay: $nextMonitoringTime")
+            return delay
+        }
+
+        /**
+         * 심박수 모니터링 시간 계산
+         * 1. 30분 간격으로 심박수 모니터링 한다.
+         * 2. 근무 시간에만 모니터링해야 한다. -> 심박수 모니터링은 아침 8시 - 저녁 7시까지로 정한다.
+         * 3. 주말(토요일, 일요일)에는 모니터링하지 않는다.
+         * @param intervalMinutes 심박수 모니터링 간격(default = 30분)
+         */
+        private fun getNextMonitoringTime(intervalMinutes: Int = 30): LocalDateTime {
+            val currentTime = LocalDateTime.now()
+
+            // 모니터링 30분 기준 계산
+            var nextMonitoringTime = if (currentTime.minute > intervalMinutes) {
+                LocalDateTime.of(
+                    currentTime.year,
+                    currentTime.month,
+                    currentTime.dayOfMonth,
+                    currentTime.hour + 1,
+                    0
+                )
+            }
+            else {
+                LocalDateTime.of(
+                    currentTime.year,
+                    currentTime.month,
+                    currentTime.dayOfMonth,
+                    currentTime.hour,
+                    intervalMinutes
+                )
+            }
+
+            // 다음 모니터링 시간이 금요일 7시 이후~일요일 사이인 경우 모니터링은 다음주 월요일 8시
+            nextMonitoringTime = when (nextMonitoringTime.dayOfWeek) {
+                DayOfWeek.SATURDAY -> nextMonitoringTime.plusDays(2).withHour(8).withMinute(0)
+                DayOfWeek.SUNDAY -> nextMonitoringTime.plusDays(1).withHour(8).withMinute(0)
+                else -> nextMonitoringTime
+            }
+
+            // 다음 모니터링 시간이 오전 8시 이전인 경우 다음 모니터링은 아침 8시
+            if (nextMonitoringTime.hour < 8) {
+                nextMonitoringTime = LocalDateTime.of(
+                    currentTime.year,
+                    currentTime.month,
+                    currentTime.dayOfMonth,
+                    8,
+                    0
+                )
+            }
+
+            // 다음 모니터링 시간이 오후 7시 이후인 경우 다음 모니터링은 다음날 아침 8시
+            if (nextMonitoringTime.hour >= 19) {
+                nextMonitoringTime = LocalDateTime.of(
+                    currentTime.year,
+                    currentTime.month,
+                    currentTime.dayOfMonth + 1,
+                    8,
+                    0
+                )
+            }
+
+            return nextMonitoringTime
+        }
+    }
+}


### PR DESCRIPTION
### 심박수 모니터링
+ 워크매니저를 통해 30분 간격으로 심박수 모니터링 한다.
+ 모니터링한 심박수는 prefs에 최근 심박수로 저장한다.
+ 모니터링한 심박수는 파이어베이스에 보낸다.

#### 모니터링 조건 : 근무 시간에만 모니터링
1) 아침 8시 - 저녁 7시까지 심박수 모니터링한다.
2) 주말(토요일, 일요일)에는 모니터링하지 않는다.

#### 모니터링 기능 추가적인 디버그가 필요함
- 현재 디버깅 : 백그라운드에서 심박수 측정이 잘 안됨
- [x] 워크매니저가 실행이 안됨  -> 해결
실행 안되는 이유 :  워크매니저 프로바이더 등록을 안했음
- [x] 딜레이 계산 문제 -> 문제없음.
- [x] 심박수 백그라운드 측정 문제 
심박수 측정 로그 확인 결과 availability가 ACQUIRING만 존재 -> 심박수 측정이 백그라운드에서는 AVAILABLE이 안됨 -> 심박수 측정 플로우를 메인 스레드에서 실행되도록 변경
- [x] 심박수 통신문제 -> 네트워크 환경이면 문제 없음
- [ ] 30분 간격에서 모니터링 디버깅 필요

#### 심박수 모니터링을 워크매니저로 구현하기로 선택한 이유
1. 전력효율과 관련된 문제. 워크매니저가 전력 효율 관련해서 가장 좋은 전략이라 생각 
2. 워크매니저 단점은 긴 주기를 딜레이로 줄 때, 부정확한 시간이 문제인데 30분 주기는 크게 문제가 되지 않음
3. 백그라운드에서 실행되고, 기기 재부팅해도 취소되지 않아야함. ->따로 시스템부트 리시버 구현할 필요가 없음